### PR TITLE
State getter, make rotate public

### DIFF
--- a/src/OrbitControls.ts
+++ b/src/OrbitControls.ts
@@ -407,6 +407,12 @@ export class OrbitControls extends EventDispatcher {
 
   getAzimuthalAngle = () => this.spherical.theta;
 
+  setPolarAngle = (phi: number) => (this.spherical.phi = phi);
+
+  setAzimuthalAngle = (theta: number) => (this.spherical.theta = theta);
+
+  getState = () => this.state;
+
   saveState = () => {
     this.target0.copy(this.target);
     this.position0.copy(this.object.position);

--- a/src/OrbitControls.ts
+++ b/src/OrbitControls.ts
@@ -407,10 +407,6 @@ export class OrbitControls extends EventDispatcher {
 
   getAzimuthalAngle = () => this.spherical.theta;
 
-  setPolarAngle = (phi: number) => (this.spherical.phi = phi);
-
-  setAzimuthalAngle = (theta: number) => (this.spherical.theta = theta);
-
   getState = () => this.state;
 
   saveState = () => {
@@ -480,11 +476,11 @@ export class OrbitControls extends EventDispatcher {
     return 0.95 ** this.zoomSpeed;
   };
 
-  private rotateLeft = (angle: number) => {
+  rotateLeft = (angle: number) => {
     this.sphericalDelta.theta -= angle;
   };
 
-  private rotateUp = (angle: number) => {
+  rotateUp = (angle: number) => {
     this.sphericalDelta.phi -= angle;
   };
 


### PR DESCRIPTION
Added `getState` method and made `rotateLeft` and `rotateUp` public. These are needed for custom controls- in my case tweening the camera back to the center when a user releases their finger.