### PR TITLE
Update OrbitControls.ts

### DIFF
--- a/src/OrbitControls.ts
+++ b/src/OrbitControls.ts
@@ -217,7 +217,7 @@ export class OrbitControls extends EventDispatcher {
         this.object.up,
         new Vector3(0, 1, 0)
       );
-      const quatInverse = quat.clone().inverse();
+      const quatInverse = quat.clone().invert();
 
       const lastPosition = new Vector3();
       const lastQuaternion = new Quaternion();


### PR DESCRIPTION
I am using expo-three with three.js.
After updating three.js to 0.128 I get the warning:

WARN THREE.Quaternion: .inverse() has been renamed to invert().

But I have no line in my code with: .inverse()

OrbitControls uses e.g. the

var quatInverse = quat.clone().inverse();

Yes, without OrbitControlsView there is no warning!