### PR TITLE
WARN THREE.Quaternion: .inverse() has been renamed to invert().

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-dom": "~16.9.0",
     "react-native": "~0.61",
     "react-native-web": "^0.11",
-    "three": "^0.108.0"
+    "three": "^0.128.0"
   },
   "dependencies": {
     "react-native-web-hooks": "^3.0.1"


### PR DESCRIPTION
I am using expo-three with three.js.
After updating three.js to 0.128 I get the warning:

WARN THREE.Quaternion: .inverse() has been renamed to invert().

But I have no line in my code with: .inverse()

OrbitControls uses e.g. the

var quatInverse = quat.clone().inverse();

Yes, without OrbitControlsView there is no warning!