### PR TITLE
Fix deprecated method name in latest versions of THREE

### DIFF
--- a/src/OrbitControls.ts
+++ b/src/OrbitControls.ts
@@ -217,7 +217,7 @@ export class OrbitControls extends EventDispatcher {
         this.object.up,
         new Vector3(0, 1, 0)
       );
-      const quatInverse = quat.clone().invert();
+      const quatInverse = quat.clone().inverse();
 
       const lastPosition = new Vector3();
       const lastQuaternion = new Quaternion();


### PR DESCRIPTION
I’m using the latest version of THREE in my branch (pr coming soon to `expo-three`) and this was required to get the orbit controls working since `Quaternion.invert()` was changed to `Quaternion.inverse()` in version 0.142.0.

If anyone else needs it, here's the patch: 

`expo-three-orbit-controls+2.0.0.patch`:

```patch
diff --git a/node_modules/expo-three-orbit-controls/build/OrbitControls.js b/node_modules/expo-three-orbit-controls/build/OrbitControls.js
index 5540eb2..7bd2d6d 100644
--- a/node_modules/expo-three-orbit-controls/build/OrbitControls.js
+++ b/node_modules/expo-three-orbit-controls/build/OrbitControls.js
@@ -631,7 +631,8 @@ export class OrbitControls extends EventDispatcher {
             const offset = new Vector3();
             // so camera.up is the orbit axis
             const quat = new Quaternion().setFromUnitVectors(this.object.up, new Vector3(0, 1, 0));
-            const quatInverse = quat.clone().inverse();
+            // This patch fixes a deprecated method name in the latest version of THREE
+            const quatInverse = quat.clone().invert();
             const lastPosition = new Vector3();
             const lastQuaternion = new Quaternion();
             return () => {
```